### PR TITLE
Pass debug flag to child elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@condenast/xml-to-react",
+  "name": "andculturecode.javascript.xml-to-react",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "andculturecode.javascript.xml-to-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Converts an XML document into a React tree",
   "main": "dist/commonjs/XMLToReact.js",
   "module": "dist/modules/XMLToReact.js",

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -119,7 +119,7 @@ export function visitNode(node, index, converters, data, debug) {
   const newProps = Object.assign({}, { key: index }, props);
 
   const children = getChildren(node);
-  const visitChildren = (child, childIndex) => visitNode(child, childIndex, converters, data);
+  const visitChildren = (child, childIndex) => visitNode(child, childIndex, converters, data, debug);
   const childElements = children.map(visitChildren);
 
   return createElement(type, newProps, ...childElements);

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -132,6 +132,16 @@ describe('helpers', () => {
       expect(console.log).toHaveBeenCalledTimes(1);
     });
 
+    it('should log message if no converter is registered by tagName for nested elements if debug is enabled', () => {
+      jest.spyOn(global.console, 'log');
+      const converters = {
+        div: () => ({ type: 'foo', props: {} }),
+      };
+      const { firstChild } = parseXML('<div><a>hello</a></div>');
+      visitNode(firstChild, 0, converters, null, true);
+      expect(console.log).toHaveBeenCalledTimes(1);
+    });
+
     it('should return `null` if node has no tagName', () => {
       const { firstChild } = parseXML('<!-- comment here -->');
       expect(visitNode(firstChild, 0, {})).toEqual(null);


### PR DESCRIPTION
## Description
When an XML node has a child nodes, the debug flag was not passed along to visitNode.  Therefore, only the top level node would trigger a debug console.log.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore, documentation, cleanup

## Related Issue
This is a bug fix for https://github.com/CondeNast/xml-to-react/pull/129.  

## Motivation and Context
Additional testing with https://github.com/CondeNast/xml-to-react/pull/129 found that the debug output was not present for child nodes.

## How Has This Been Tested?
Added an additional unit test, as well as manual testing within a project.

## Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
