### PR TITLE
Add ability to register default fallback converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ The `XMLToReact` class is instantiated with a map of converters.
 }
 ```
 
+You can also register a default fallback converter by registering it with `'*'` as the key. This
+converter will be used if no explicit converter is registered for the XML node name.
+
+```js
+{
+  '*': defaultConverterFunction
+}
+```
+
 ### `convert( xml, data )`
 
 - `xml` `{string}` - xml node or document

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -104,12 +104,12 @@ export function visitNode(node, index, converters, data, debug) {
     return null;
   }
 
-  const converter = converters[tagName];
+  const converter = converters[tagName] || converters['*'];
 
   if (typeof converter !== 'function') {
     if (debug === true) {
       // eslint-disable-next-line no-console
-      console.log(`No converter found for tagName "${tagName}"`);
+      console.log(`No converter found for tagName "${tagName}" and no default converter specified.`);
     }
     return null;
   }
@@ -119,7 +119,7 @@ export function visitNode(node, index, converters, data, debug) {
   const newProps = Object.assign({}, { key: index }, props);
 
   const children = getChildren(node);
-  const visitChildren = (child, childIndex) => visitNode(child, childIndex, converters, data, debug);
+  const visitChildren = (child, childIdx) => visitNode(child, childIdx, converters, data, debug);
   const childElements = children.map(visitChildren);
 
   return createElement(type, newProps, ...childElements);

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -129,6 +129,7 @@ describe('helpers', () => {
       const converters = {};
       const { firstChild } = parseXML('<a>hello</a>');
       visitNode(firstChild, 0, converters, null, true);
+      // eslint-disable-next-line no-console
       expect(console.log).toHaveBeenCalledTimes(1);
     });
 
@@ -139,6 +140,7 @@ describe('helpers', () => {
       };
       const { firstChild } = parseXML('<div><a>hello</a></div>');
       visitNode(firstChild, 0, converters, null, true);
+      // eslint-disable-next-line no-console
       expect(console.log).toHaveBeenCalledTimes(1);
     });
 
@@ -230,6 +232,17 @@ describe('helpers', () => {
       expect(isValidElement(element)).toEqual(true);
       expect(cat.type).toEqual('li');
       expect(cat.props).toEqual({ action: 'purr', children: 'Billy' });
+    });
+
+    it('should use default converter if none found for tag name', () => {
+      const converters = {
+        '*': () => ({ type: 'div', props: {} }),
+      };
+      const { firstChild } = parseXML('<UnregisteredXmlTag>I should be converted using "*" converter</UnregisteredXmlTag>');
+      const element = visitNode(firstChild, 0, converters);
+
+      expect(isValidElement(element)).toEqual(true);
+      expect(element.type).toEqual('div');
     });
   });
 });


### PR DESCRIPTION
## Description
Added the ability to add a default converter. If no explicit converter is registered for a given XML node name, the default converter will be used as a fallback, if one is registered.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore, documentation, cleanup

## Motivation and Context
This feature is needed by a client project so that we can show unhandled XML nodes with some indicative styling so that it stands out as something we need to address. This feature will be feature-flagged.

## How Has This Been Tested?
Added unit tests to verify that, if no explicit converter is registered for the XML tag, and a default converter is registered, then the default converter is used.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
