### PR TITLE
Add tagName to xml-to-react converted component props

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,4 +21,11 @@ declare class XMLToReact {
   public convert(xml: string, data?: any): any;
 }
 
+declare namespace XMLToReact {
+  declare interface XMLToReactComponentProps {
+    key: number,
+    tagName: string;
+  }
+}
+
 export = XMLToReact;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -116,7 +116,7 @@ export function visitNode(node, index, converters, data, debug) {
 
   const attributes = getAttributes(node);
   const { type, props } = converter(attributes, data);
-  const newProps = Object.assign({}, { key: index }, props);
+  const newProps = Object.assign({}, { key: index, tagName }, props);
 
   const children = getChildren(node);
   const visitChildren = (child, childIdx) => visitNode(child, childIdx, converters, data, debug);

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -185,6 +185,7 @@ describe('helpers', () => {
       expect(element.props).toEqual({
         children: 'hello',
         keys: ['x', 'y'],
+        tagName: 'a',
       });
     });
 
@@ -207,6 +208,7 @@ describe('helpers', () => {
       expect(element.props).toEqual({
         foo: 'bar',
         children: 'hello',
+        tagName: 'a',
       });
       expect(props).toEqual({ foo: 'bar' });
     });
@@ -227,11 +229,19 @@ describe('helpers', () => {
 
       expect(isValidElement(element)).toEqual(true);
       expect(dog.type).toEqual('li');
-      expect(dog.props).toEqual({ action: 'wag', children: 'Rufus' });
+      expect(dog.props).toEqual({
+        action: 'wag',
+        children: 'Rufus',
+        tagName: 'Dog',
+      });
 
       expect(isValidElement(element)).toEqual(true);
       expect(cat.type).toEqual('li');
-      expect(cat.props).toEqual({ action: 'purr', children: 'Billy' });
+      expect(cat.props).toEqual({
+        action: 'purr',
+        children: 'Billy',
+        tagName: 'Cat',
+      });
     });
 
     it('should use default converter if none found for tag name', () => {
@@ -243,6 +253,7 @@ describe('helpers', () => {
 
       expect(isValidElement(element)).toEqual(true);
       expect(element.type).toEqual('div');
+      expect(element.props.tagName).toBe('UnregisteredXmlTag');
     });
   });
 });


### PR DESCRIPTION
## Description
Adds the converted XML node name to the converted react component props, and defines a Typescript interface for the props.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore, documentation, cleanup

## Motivation and Context
This will allow us to log a warning when unhandled XML nodes are encountered by the converter.

## How Has This Been Tested?
Updated `helpers.test.js` to assert `element.props.tagName`

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
